### PR TITLE
docs(readme): include connection instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ the password and will have established connection succesfully!
 > [!TIP]
 Make sure that you are connected to the "Nube" Wi-Fi before attempting to
 connect to the VM.
+
+### Connecting to the Web App
+
+In order to connect to the Web App as deployed in the cloud server, one simply
+must open the IP `172.16.61.182` on their web browser while being connected to
+the "Nube" Wi-Fi network on campus.


### PR DESCRIPTION
Different from the `ssh` instructions, which grant access to the cloud server itself, these instructions detail how an end-user should attempt to connect to the web app.

Closes #25.